### PR TITLE
upgrade debian version in docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:14.17.0
+FROM node:14.21.3-bullseye
 
 ENV NODE_ENV=development
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:14.17.0
+FROM node:14.21.3-bullseye
 
 ENV NODE_ENV=development
 


### PR DESCRIPTION
Update docker container to latest stable Debian release ("bullseye") and latest version of Node.js 14, to fix this build error on MacOS:

```
error - unhandledRejection: Error: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /app/node_modules/sodium-native/prebuilds/linux-arm64/node.napi.node)
    at Object.Module._extensions..node (internal/modules/cjs/loader.js:1127:18)
    at Module.load (internal/modules/cjs/loader.js:933:32)
    at Function.Module._load (internal/modules/cjs/loader.js:774:14)
    at Module.require (internal/modules/cjs/loader.js:957:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at load (/app/node_modules/node-gyp-build/index.js:22:10)
    at Object.<anonymous> (/app/node_modules/sodium-native/index.js:1:43)
    at Module._compile (internal/modules/cjs/loader.js:1068:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:933:32)
```